### PR TITLE
Added ISODate (ISO 8601) function and set as default in index.tmpl

### DIFF
--- a/src/post.go
+++ b/src/post.go
@@ -81,6 +81,10 @@ func (p *post) ReadableDate() string {
 	return p.PostTime.Format("2 January 2006")
 }
 
+func (p *post) ISODate() string {
+	return p.PostTime.Format("2006-01-02")
+}
+
 func (p *post) ISOTime() string {
 	return p.PostTime.Format(time.RFC3339)
 }

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -2,6 +2,6 @@
 
 # {{.Title}}
 {{range .Posts}}
-=> {{.Filename}} {{.ReadableDate}}: {{.Title}}{{end}}
+=> {{.Filename}} {{.ISODate}} - {{.Title}}{{end}}
 
 => {{.URL}}/atom.xml Feed


### PR DESCRIPTION
Hello! I noticed the companion spec for gemlog subscriptions (gemini://gemini.circumlunar.space/docs/companion/subscription.gmi) requires dates to be formatted according to ISO 8601 (i.e. `YYYY-MM-DD`), so I added a function `ISODate` and set it as the default on `templates/index.tmpl`, so gemlogs can be subscribed to using clients that follow the companion spec.